### PR TITLE
Netlify deploys as a white page

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,5 @@
     "stylelint-config-standard": "19.0.0",
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.8.0"
-  },
-  "resolutions": {
-    "gatsby": "2.15.28"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "gatsby-plugin-manifest": "2.2.20",
     "gatsby-plugin-netlify": "2.1.17",
     "gatsby-plugin-robots-txt": "1.5.0",
-    "react": "16.10.1",
-    "react-dom": "16.10.1"
+    "react": "16.9.0",
+    "react-dom": "16.9.0"
   },
   "devDependencies": {
     "eslint": "6.5.1",
@@ -27,5 +27,8 @@
     "stylelint-config-standard": "19.0.0",
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.8.0"
+  },
+  "resolutions": {
+    "gatsby": "2.15.28"
   }
 }


### PR DESCRIPTION
When loading https://montrealphoto.club I briefly see the content of the page before it switches to an all-white page. 

It started messing up with https://deploy-preview-47--montrealphotoclub.netlify.com/
But it was working fine with https://deploy-preview-43--montrealphotoclub.netlify.com/

It works locally but I guess it has something to do with the way Netlify builds. Knowing their support team, they will dodge and ask me to debug myself with their effing docker image.

Worst thing is that it built without issue and passed the checks, so I haven't checked in further details before today. 

DP47 was the update of React but trying first to remove the resolutions thing then trying to revert back to a previous react version. 